### PR TITLE
Changed max yintercept to 30 on line 266

### DIFF
--- a/book/12-missing-data.Rmd
+++ b/book/12-missing-data.Rmd
@@ -263,7 +263,7 @@ messy %>%
   geom_violin() +
   geom_boxplot() +
   geom_jitter(width = .2) +
-  geom_hline(yintercept = c(0,40), color = "red", linetype = 2)
+  geom_hline(yintercept = c(0,30), color = "red", linetype = 2)
 ```
 
 Alternatively you could also use a histogram to spot an outlier:


### PR DESCRIPTION
Student commented that using 40 as a maximum value does not make much sense when the aim is to highlight where the upper limit should be (i.e., 30). I would also argue 0 is not quite right since the start of the chapter explains minus values are possible, but I don't know what you would set for this instead as we don't know an absolute lower limit.